### PR TITLE
Fix for tab layout on Firefox 133.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
         mkdir -p tmp_css
         curl -L -o tmp_css/tabs_on_bottom.css https://raw.githubusercontent.com/MrOtherGuy/firefox-csshacks/master/chrome/tabs_on_bottom.css
         curl -L -o tmp_css/tabs_on_bottom_menubar_on_top_patch.css https://raw.githubusercontent.com/MrOtherGuy/firefox-csshacks/master/chrome/tabs_on_bottom_menubar_on_top_patch.css
+        curl -L -o tmp_css/tabs_on_bottom_v2.css https://raw.githubusercontent.com/MrOtherGuy/firefox-csshacks/master/chrome/tabs_on_bottom_v2.css
 
     - name: Check for changes
       id: check_changes

--- a/IE6/chrome/hacks/tabs_on_bottom_v2.css
+++ b/IE6/chrome/hacks/tabs_on_bottom_v2.css
@@ -1,0 +1,52 @@
+/* Source file https://github.com/MrOtherGuy/firefox-csshacks/tree/master/chrome/tabs_on_bottom_v2.css made available under Mozilla Public License v. 2.0
+See the above repository for updates as well as full license text. */
+
+/* This reorders toolbar to place tabs below other toolbars. Requires Firefox 133+ */
+
+@media (-moz-bool-pref: "userchrome.force-window-controls-on-left.enabled"){
+	#nav-bar > .titlebar-buttonbox-container{
+	  order: -1 !important;
+	  > .titlebar-buttonbox{
+		flex-direction: row-reverse;
+	  }
+	}
+  }
+  @media not (-moz-bool-pref: "sidebar.verticalTabs"){
+	.global-notificationbox,
+	#tab-notification-deck,
+	#TabsToolbar{
+	  order: 1;
+	}
+	#TabsToolbar > :is(.titlebar-spacer,.titlebar-buttonbox-container){
+	  display: none;
+	}
+	:root[sizemode="fullscreen"] #nav-bar > .titlebar-buttonbox-container{
+	  display: flex !important;
+	}
+	:root[tabsintitlebar] #toolbar-menubar:not([autohide="false"]) ~ #nav-bar{
+	  > .titlebar-buttonbox-container{
+		display: flex !important;
+	  }
+	  :root[sizemode="normal"] & {
+		> .titlebar-spacer{
+		  display: flex !important;
+		}
+	  }
+	  :root[sizemode="maximized"] & {
+		> .titlebar-spacer[type="post-tabs"]{
+		  display: flex !important;
+		}
+		@media (-moz-bool-pref: "userchrome.force-window-controls-on-left.enabled"),
+		  (-moz-gtk-csd-reversed-placement),
+		  (-moz-platform: macos){
+		  > .titlebar-spacer[type="post-tabs"]{
+			display: none !important;
+		  }
+		  > .titlebar-spacer[type="pre-tabs"]{
+			display: flex !important;
+		  }
+		}
+	  }
+	}
+  }
+  

--- a/IE6/chrome/toolbars.css
+++ b/IE6/chrome/toolbars.css
@@ -1,4 +1,4 @@
-@import "hacks/tabs_on_bottom.css";
+@import "hacks/tabs_on_bottom_v2.css"; /* Firefox 133 and below? remove '_v2' */
 @import "hacks/tabs_on_bottom_menubar_on_top_patch.css";
 
 /* Hacks overrides*/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ If you're using Pale Moon browser, Use **[Modoki Moon][mmm]** instead of this - 
 
 This theme pairs beautifully with the **[Chicago95 theme for XFCE][c95]**.
 
+> [!IMPORTANT]  
+> In **Firefox 133** and above, there were significant changes to the layout. If you are using a Firefox version lower than this, then install **version 0.9**.
+
  ℹ️ If you want compact density, set `browser.compactmode.show` to `true`.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/soup-bowl/Modoki-Firefox)


### PR DESCRIPTION
Fixes the tabs on bottom layout for Firefox 133 and above.

This has **breaking changes** to Firefox below 133. An instruction is added to the README and a new verion release is planned.

Merge in when Firefox 133 is either released, or close to.