### PR TITLE
Added media selectors to exclude menu hacks from macos clients

### DIFF
--- a/IE6/chrome/toolbars.css
+++ b/IE6/chrome/toolbars.css
@@ -1,15 +1,18 @@
 @import "hacks/tabs_on_bottom_v2.css"; /* Firefox 133 and below? remove '_v2' */
-@import "hacks/tabs_on_bottom_menubar_on_top_patch.css";
+@import "hacks/tabs_on_bottom_menubar_on_top_patch.css" not (-moz-platform: macos);
+
 
 /* Hacks overrides*/
-#navigator-toolbox {
-	padding-top: calc(23px + var(--uc-titlebar-padding, 0px)) !important;
-}
+@media not(-moz-platform: macos){
+	
+	#navigator-toolbox {
+		padding-top: calc(23px + var(--uc-titlebar-padding, 0px)) !important;
+	}
 
-#toolbar-menubar {
-	height: 23px !important;
+	#toolbar-menubar {
+		height: 23px !important;
+	}
 }
-
 /* ! Hacks overrides*/
 
 


### PR DESCRIPTION
Adds media selectors on the import statement and to the hacks overrides which directly deal with the menu-bar padding to prevent these from being loaded on Macintosh clients. This removes the empty gap at the top of the window where the menu bar ought to go. 

This fixes #43 , at least insofar as hiding a problem fixes it. Obviously, limitations of Firefox on mac mean we can't have the menu bar properly inside the application, but considering that's the way MacOS has always worked, I'm satisfied with the outcome. 

In my admittedly limited testing it doesn't appear to break anything on Linux, at least on my machine. Tested on the latest Firefox (144.0.2) as well as the ESR release (140.4.0esr) both on XFCE and it appears to work as I'd expect on those platforms - menu bar shows up as expected and with the appropriate padding. 

And obviously I tested it on MacOS, where it did what I wanted it to: not show the empty space where the menu bar was supposed to go.